### PR TITLE
Fix identification and dependencies in Docker POM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 # Version: 0.0.1
-FROM tomcat:8.0.18-jre8
+
+FROM tomcat:7.0.59-jre7
 MAINTAINER Grigory Silantyev <gsilantyev@griddynamics.com>
-ADD /target/asf-webapp-demo.war /usr/local/tomcat/webapps/asf-webapp-demo.war
-EXPOSE 8080
+
+COPY target/files/spring-petclinic.war /usr/local/tomcat/webapps/asf-webapp-demo.war
+

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -6,10 +6,19 @@
         <artifactId>asf-webapp-demo</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>spring-petclinic</artifactId>
+    <artifactId>asf-webapp-docker</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>spring-petclinic</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
 
     <build>
-        <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -17,23 +26,18 @@
                 <version>2.10</version>
                 <executions>
                     <execution>
-                        <id>copy</id>
+                        <id>copy-dependencies</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>copy</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.griddynamics.asf.webapp-demo</groupId>
-                                    <artifactId>spring-petclinic</artifactId>
-                                    <version>1.0.0-SNAPSHOT</version>
-                                    <type>war</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>asf-webapp-demo.war</destFileName>
-                                </artifactItem>
-                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/files</outputDirectory>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <excludeTransitive>true</excludeTransitive>
+                            <!-- Format for output file names -->
+                            <stripClassifier>true</stripClassifier>
+                            <stripVersion>true</stripVersion>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fixed issues in POM of docker module:
 - artifactId of docker module duplicated another another module.
 - Build order was undefined.
 - WAR version was hard-coded.

RTFM: http://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html

Fixed issues in Dockerfile:
 - Tomcat 8 was used while the application was tested against Tomcat 7.
 - JRE 8 was used while the application was built for JRE 7.
 - Duplicated instruction from the base Docker image adds extra layer.